### PR TITLE
No longer move node-ci.yml in init

### DIFF
--- a/.github/workflows/template_initialization.yaml
+++ b/.github/workflows/template_initialization.yaml
@@ -16,7 +16,6 @@ jobs:
       - uses: actions/checkout@v2
       - run: |
           mv README.template.md README.md
-          mv .github/node-ci.yml .github/workflows/node-ci.yml
 
       - name: Replace tokens in README.MD and package.json
         uses: cschleiden/replace-tokens@v1


### PR DESCRIPTION
Not needed after https://github.com/wikimedia-gadgets/twinkle-starter/commit/277461aa167ec339f6f42dab2a08652b63b43684#diff-be891c5470f83d305ee76f877cb1db28b80951b85f42dae02e9fb8ad44df6886