### PR TITLE
dev-loader.js: Replace removed alias es6-promise with es6-polyfills

### DIFF
--- a/dev-loader.js
+++ b/dev-loader.js
@@ -17,7 +17,7 @@
 
 mw.loader.using([
 	'mediawiki.api', 'mediawiki.Title', 'mediawiki.user', 'mediawiki.util',
-	'mediawiki.libs.pluralruleparser', 'es6-promise'
+	'mediawiki.libs.pluralruleparser', 'es6-polyfills'
 ]).then(function() {
 	mw.loader.getScript('http://localhost:5500/core/morebits/morebits.js').then(function () {
 		mw.loader.getScript('http://localhost:5500/twinkle.js');


### PR DESCRIPTION
es6-promise was replaced with and aliased to es6-polyfills. The alias
was deprecated, and recently removed on Wikimedia wikis.
See https://gerrit.wikimedia.org/r/c/mediawiki/core/+/681507